### PR TITLE
Add validate schema utils

### DIFF
--- a/roboswag/core.py
+++ b/roboswag/core.py
@@ -3,6 +3,7 @@ import urllib3
 
 from roboswag.auth import TokenHandler
 from roboswag.logger import Logger
+from roboswag.validate import ValidateSchema
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
@@ -30,6 +31,7 @@ class APIModel:
             self.session.proxies.update(proxies)
         self.authorization = authorization
         self.logger = Logger()
+        self.validate = ValidateSchema()
         if headers is not None:
             self.session.headers.update(headers)
 

--- a/roboswag/generate/templates/paths.jinja
+++ b/roboswag/generate/templates/paths.jinja
@@ -57,11 +57,8 @@ class {{ class_name }}(APIModel):
         if validate_schema:{% for status_code, resp in endpoint.responses.items() %}
         {%- if resp.schema %}
             {% if not loop.first %}el{% endif %}if response.status_code == {{ status_code }}:
-                try:
-                    schema = {{ resp.schema }}
-                    validate(instance=json.loads(response.text), schema=schema)
-                except jsonschema.exceptions.ValidationError as err:
-                    raise err
+                schema = {{ resp.schema }}
+                self.validate.schema(response, schema)
         {%- elif status_code != "default" %}
             {% if not loop.first %}el{% endif %}if response.status_code == {{ status_code }}:
                 expected_text = "{{ resp.description }}"

--- a/roboswag/validate/__init__.py
+++ b/roboswag/validate/__init__.py
@@ -1,0 +1,1 @@
+from roboswag.validate.schema import ValidateSchema

--- a/roboswag/validate/schema.py
+++ b/roboswag/validate/schema.py
@@ -1,0 +1,17 @@
+import json
+from pathlib import Path
+from typing import Dict, Union
+
+import jsonschema
+
+
+class ValidateSchema:
+    @staticmethod
+    def schema(response, schema: Union[str, Path, Dict]):
+        if isinstance(schema, (str, Path)):
+            with open(schema) as fp:
+                schema = json.load(fp)
+        try:
+            jsonschema.validate(instance=response.json(), schema=schema)
+        except jsonschema.exceptions.ValidationError as err:
+            raise err

--- a/tests/validate/test_data/invalid_schema.json
+++ b/tests/validate/test_data/invalid_schema.json
@@ -1,0 +1,15 @@
+{
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "unknown",
+          "format": "int32"
+        },
+        "type": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+}

--- a/tests/validate/test_data/invalid_schema_json.json
+++ b/tests/validate/test_data/invalid_schema_json.json
@@ -1,0 +1,14 @@
+{
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "type": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        }
+      }

--- a/tests/validate/test_data/valid_schema.json
+++ b/tests/validate/test_data/valid_schema.json
@@ -1,0 +1,15 @@
+{
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "type": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+}

--- a/tests/validate/test_validate_schema.py
+++ b/tests/validate/test_validate_schema.py
@@ -1,0 +1,61 @@
+import json
+from pathlib import Path
+from unittest.mock import Mock
+
+import jsonschema
+import pytest
+
+from roboswag.validate import ValidateSchema
+
+TEST_DATA = Path(__file__).parent / "test_data"
+VALID_SCHEMA = TEST_DATA / "valid_schema.json"
+INVALID_SCHEMA = TEST_DATA / "invalid_schema.json"
+INVALID_SCHEMA_JSON = TEST_DATA / "invalid_schema_json.json"
+
+
+@pytest.fixture
+def validator():
+    return ValidateSchema
+
+
+@pytest.fixture
+def valid_response():
+    response = Mock()
+    response_json = {"code": 123, "type": "abc", "message": "abc"}
+    response.json = Mock(return_value=response_json)
+    return response
+
+
+@pytest.fixture
+def invalid_response():
+    response = Mock()
+    response.json = Mock(return_value={"code": "123"})
+    return response
+
+
+def test_validate_valid_schema_path(validator, valid_response):
+    validator.schema(valid_response, VALID_SCHEMA)
+
+
+def test_validate_valid_schema(validator, valid_response):
+    with open(VALID_SCHEMA) as fp:
+        schema = json.load(fp)
+    validator.schema(valid_response, schema)
+
+
+@pytest.mark.skip("Missing error handling")
+def test_validate_invalid_schema_json(validator, valid_response):
+    # FIXME add error handling (raises JSOnDecodeError)
+    validator.schema(valid_response, INVALID_SCHEMA_JSON)
+
+
+@pytest.mark.skip("Missing error handling")
+def test_validate_invalid_schema(validator, valid_response):
+    # Raises jsonschema.exceptions.SchemaError: 'unknown' is not valid under any of the given schemas
+    validator.schema(valid_response, INVALID_SCHEMA)
+
+
+def test_validate_invalid_response(validator, invalid_response):
+    # TODO: Custom exception from Roboswag (with error stack on debug only)
+    with pytest.raises(jsonschema.exceptions.ValidationError, match="'123' is not of type 'integer'"):
+        validator.schema(invalid_response, VALID_SCHEMA)


### PR DESCRIPTION
Moved validate schema to separate class. It's starting point to having all validations done in respective classes. 

Also added unit tests - we're kind of testing not only our validate schema method but also jsonschema validate functionality as well (if they broke something, we should be able to catch it).

Partly implements #41