### PR TITLE
Validate errors

### DIFF
--- a/roboswag/core.py
+++ b/roboswag/core.py
@@ -3,7 +3,7 @@ import urllib3
 
 from roboswag.auth import TokenHandler
 from roboswag.logger import Logger
-from roboswag.validate import ValidateSchema
+from roboswag.validate import Validate
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
@@ -31,7 +31,7 @@ class APIModel:
             self.session.proxies.update(proxies)
         self.authorization = authorization
         self.logger = Logger()
-        self.validate = ValidateSchema(self.logger)
+        self.validate = Validate(self.logger)
         if headers is not None:
             self.session.headers.update(headers)
 

--- a/roboswag/generate/templates/paths.jinja
+++ b/roboswag/generate/templates/paths.jinja
@@ -1,7 +1,4 @@
 import logging
-
-import jsonschema
-from jsonschema import validate
 import json
 
 from roboswag import APIModel
@@ -40,11 +37,8 @@ class {{ class_name }}(APIModel):
 {%- if endpoint.body %}
         if validate_payload:
         {%- if endpoint.body.schema %}
-            try:
-                schema = {{ endpoint.body.schema }}
-                validate(instance=json.loads(body), schema=schema)
-            except jsonschema.exceptions.ValidationError as err:
-                raise err
+            schema = {{ endpoint.body.schema }}
+            self.validate.schema(json.loads(body), schema)
         {%- endif %}
 
         _body = {{ endpoint.body.python_name }}
@@ -58,7 +52,7 @@ class {{ class_name }}(APIModel):
         {%- if resp.schema %}
             {% if not loop.first %}el{% endif %}if response.status_code == {{ status_code }}:
                 schema = {{ resp.schema }}
-                self.validate.schema(response, schema)
+                self.validate.schema(response.json(), schema)
         {%- elif status_code != "default" %}
             {% if not loop.first %}el{% endif %}if response.status_code == {{ status_code }}:
                 self.validate.error(response, "{{ resp.description }}")

--- a/roboswag/generate/templates/paths.jinja
+++ b/roboswag/generate/templates/paths.jinja
@@ -61,16 +61,10 @@ class {{ class_name }}(APIModel):
                 self.validate.schema(response, schema)
         {%- elif status_code != "default" %}
             {% if not loop.first %}el{% endif %}if response.status_code == {{ status_code }}:
-                expected_text = "{{ resp.description }}"
-                assertion_err_msg = f"Received response description:\n    '{response.text}'\n" \
-                                    f"does not equal expected:\n    '{expected_text}'"
-                assert response.text == expected_text, assertion_err_msg
+                self.validate.error(response, "{{ resp.description }}")
         {%- else %}
             {% if not loop.first %}el{% endif %}if response.status_code == "default":
-                expected_text = "{{ resp.description }}"
-                assertion_err_msg = f"Received response description:\n    '{response.text}'\n" \
-                                    f"does not equal expected:\n    '{expected_text}'"
-                assert response.text == expected_text, assertion_err_msg
+                self.validate.error(response, "{{ resp.description }}")
         {%- endif %}{% endfor %}
             else:
                 logging.error(f"Received status code ({response.status_code}) is not expected by the API specification")

--- a/roboswag/validate/__init__.py
+++ b/roboswag/validate/__init__.py
@@ -1,1 +1,6 @@
+from roboswag.validate.errors import ValidateError
 from roboswag.validate.schema import ValidateSchema
+
+
+class Validate(ValidateSchema, ValidateError):
+    pass

--- a/roboswag/validate/core.py
+++ b/roboswag/validate/core.py
@@ -1,3 +1,3 @@
-class Validate:
+class ValidateBase:
     def __init__(self, logger):
         self.logger = logger

--- a/roboswag/validate/errors.py
+++ b/roboswag/validate/errors.py
@@ -1,0 +1,10 @@
+from roboswag.validate.core import ValidateBase
+
+
+class ValidateError(ValidateBase):
+    @staticmethod
+    def error(response, exp_error):
+        assertion_err_msg = (
+            f"Received response description:\n    '{response.text}'\n" f"does not equal expected:\n    '{exp_error}'"
+        )
+        assert response.tex == exp_error, assertion_err_msg

--- a/roboswag/validate/errors.py
+++ b/roboswag/validate/errors.py
@@ -7,4 +7,4 @@ class ValidateError(ValidateBase):
         assertion_err_msg = (
             f"Received response description:\n    '{response.text}'\n" f"does not equal expected:\n    '{exp_error}'"
         )
-        assert response.tex == exp_error, assertion_err_msg
+        assert response.text == exp_error, assertion_err_msg

--- a/roboswag/validate/errors.py
+++ b/roboswag/validate/errors.py
@@ -2,9 +2,10 @@ from roboswag.validate.core import ValidateBase
 
 
 class ValidateError(ValidateBase):
-    @staticmethod
-    def error(response, exp_error):
+    def error(self, response, exp_error):
+        self.logger.info("Validating error message...")
         assertion_err_msg = (
             f"Received response description:\n    '{response.text}'\n" f"does not equal expected:\n    '{exp_error}'"
         )
         assert response.text == exp_error, assertion_err_msg
+        self.logger.info("Error message is valid.")

--- a/roboswag/validate/schema.py
+++ b/roboswag/validate/schema.py
@@ -4,10 +4,10 @@ from typing import Dict, Union
 
 import jsonschema
 
-from roboswag.validate.core import Validate
+from roboswag.validate.core import ValidateBase
 
 
-class ValidateSchema(Validate):
+class ValidateSchema(ValidateBase):
     def schema(self, response, schema: Union[str, Path, Dict]):
         self.logger.info("Validating schema...")
         if isinstance(schema, (str, Path)):

--- a/roboswag/validate/schema.py
+++ b/roboswag/validate/schema.py
@@ -8,14 +8,14 @@ from roboswag.validate.core import ValidateBase
 
 
 class ValidateSchema(ValidateBase):
-    def schema(self, response, schema: Union[str, Path, Dict]):
+    def schema(self, to_validate, schema: Union[str, Path, Dict]):
         self.logger.info("Validating schema...")
         if isinstance(schema, (str, Path)):
             with open(schema) as fp:
                 schema = json.load(fp)
         self.logger.debug(f"Schema:\n{json.dumps(schema, indent=4)}")
         try:
-            jsonschema.validate(instance=response.json(), schema=schema)
+            jsonschema.validate(instance=to_validate, schema=schema)
         except jsonschema.exceptions.ValidationError as err:
             raise err
         self.logger.info("Schema is valid.")

--- a/tests/validate/test_validate_error.py
+++ b/tests/validate/test_validate_error.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from roboswag.validate import Validate
+
+
+@pytest.fixture
+def validator():
+    logger = Mock()
+    return Validate(logger=logger)
+
+
+EXPECTED_ERROR = "I am being expected"
+
+
+@pytest.fixture
+def valid_error():
+    response = Mock()
+    response.text = EXPECTED_ERROR
+    return response
+
+
+@pytest.fixture
+def invalid_error():
+    response = Mock()
+    response.text = "Not sure where I came from"
+    return response
+
+
+def test_valid_error(validator, valid_error):
+    validator.error(valid_error, EXPECTED_ERROR)
+
+
+def test_invalid_error(validator, invalid_error):
+    exp_msg = (
+        f"Received response description:\n    '{invalid_error.text}'\n"
+        f"does not equal expected:\n"
+        f"    '{EXPECTED_ERROR}'"
+    )
+    with pytest.raises(AssertionError, match=exp_msg):
+        validator.error(invalid_error, EXPECTED_ERROR)

--- a/tests/validate/test_validate_schema.py
+++ b/tests/validate/test_validate_schema.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 import jsonschema
 import pytest
 
-from roboswag.validate import ValidateSchema
+from roboswag.validate import Validate
 
 TEST_DATA = Path(__file__).parent / "test_data"
 VALID_SCHEMA = TEST_DATA / "valid_schema.json"
@@ -16,7 +16,7 @@ INVALID_SCHEMA_JSON = TEST_DATA / "invalid_schema_json.json"
 @pytest.fixture
 def validator():
     logger = Mock()
-    return ValidateSchema(logger=logger)
+    return Validate(logger=logger)
 
 
 @pytest.fixture

--- a/tests/validate/test_validate_schema.py
+++ b/tests/validate/test_validate_schema.py
@@ -21,17 +21,12 @@ def validator():
 
 @pytest.fixture
 def valid_response():
-    response = Mock()
-    response_json = {"code": 123, "type": "abc", "message": "abc"}
-    response.json = Mock(return_value=response_json)
-    return response
+    return {"code": 123, "type": "abc", "message": "abc"}
 
 
 @pytest.fixture
 def invalid_response():
-    response = Mock()
-    response.json = Mock(return_value={"code": "123"})
-    return response
+    return {"code": "123"}
 
 
 def test_validate_valid_schema_path(validator, valid_response):


### PR DESCRIPTION
Use validator class for expected errors instead of duplicating several lines in the whole endpoint class.